### PR TITLE
Change Indexing Format + Enhance Configurability

### DIFF
--- a/lmcache/experimental/cache_engine.py
+++ b/lmcache/experimental/cache_engine.py
@@ -77,13 +77,14 @@ class LMCacheEngine:
         self.token_database = token_database
         self.gpu_connector = gpu_connector
 
-        self.enable_p2p = config.enable_p2p
+        self.enable_p2p = (config.enable_p2p and config.distributed_url
+                           and ":" in config.distributed_url)
 
         # NOTE: Unix systems use fork by default
         multiprocessing.set_start_method('spawn', force=True)
 
         self.lookup_server: Optional[LookupServerInterface] = None
-        if self.enable_p2p:
+        if config.enable_p2p:
             self.lookup_server = RedisLookupServer(config)
 
         # avoid circular import
@@ -362,10 +363,32 @@ class LMCacheEngine:
         :return: An int indicating how many prefix tokens are cached.
         """
         end = 0
+        search_local = True  # we always lookup local storage_manager first
+        # secondary lookup on p2p (via lookup_server) if enabled
+        search_p2p = (self.enable_p2p
+                      and (search_range is None or "p2p" in search_range))
+
         for start, end, key in self.token_database.process_tokens(tokens):
             assert isinstance(key, CacheEngineKey)
-            if not self.storage_manager.contains(key, search_range):
-                return start
+            if search_local:
+                if self.storage_manager.contains(key, search_range):
+                    # found in storage manager, no need to search p2p
+                    continue
+                else:
+                    # key not found in storage_manager
+                    # search only p2p from now on
+                    search_local = False
+            if search_p2p:
+                assert self.lookup_server is not None
+                if self.lookup_server.lookup(key):
+                    # found in p2p
+                    # continue loop to ensure a maximal prefix match
+                    continue
+            # not found in both storage_manager and p2p,
+            # return start, which equals last iteration's end
+            return start
+
+        # all tokens where found, return the maximal end
         return end
 
     def clear(

--- a/lmcache/experimental/lookup_server/redis_server.py
+++ b/lmcache/experimental/lookup_server/redis_server.py
@@ -1,4 +1,5 @@
 import inspect
+import time
 from typing import List, Optional, Tuple
 
 import redis
@@ -31,18 +32,33 @@ class RedisLookupServer(LookupServerInterface):
         logger.info(f"Connected to Redis lookup server at {host}:{port}")
         #decode_responses=False)
 
+    def _get_indexing_key(self, key: CacheEngineKey):
+        return f"{key.model_name}@{key.chunk_hash}"
+
+    def _get_indexing_metadata(self, key: CacheEngineKey):
+        return f"{key.fmt}@{key.world_size}@{key.worker_id}@{time.time()}"
+
+    def _extract_cache_keys_componenets(self, indexing_metadata: str):
+        return indexing_metadata.split("@")[:-1]
+
     def lookup(self, key: CacheEngineKey) -> Optional[Tuple[str, int]]:
         """
         Perform lookup in the lookup server.
         """
         logger.debug("Call to lookup in lookup server")
-        url = self.connection.get(key.to_string())
-        logger.debug(f"KV cache lives on {url}")
-        assert not inspect.isawaitable(url)
-        if url is None:
+        result = self.connection.hgetall(self._get_indexing_key(key))
+        logger.debug(f"KV cache lives on {result}")
+        if not result:
             return None
-        host, port = url.split(":")
-        return host, int(port)
+        comps = self._extract_cache_keys_componenets(
+            self._get_indexing_metadata(key))
+        assert not inspect.isawaitable(result)
+        for md_key, md_value in result.items():
+            if comps == self._extract_cache_keys_componenets(md_value):
+                url = md_key
+                host, port = url.split(":")
+                return host, int(port)
+        return None
 
     def insert(self, key: CacheEngineKey):
         """
@@ -50,20 +66,27 @@ class RedisLookupServer(LookupServerInterface):
         """
         assert self.distributed_url is not None
         logger.debug("Call to insert in lookup server")
-        self.connection.set(key.to_string(), self.distributed_url)
+        self.connection.hset(self._get_indexing_key(key), self.distributed_url,
+                             self._get_indexing_metadata(key))
 
     def remove(self, key: CacheEngineKey):
         """
         Perform remove in the lookup server.
         """
         logger.debug("Call to remove in lookup server")
-        self.connection.delete(key.to_string())
+        assert self.distributed_url is not None
+        self.connection.hdel(self._get_indexing_key(key), self.distributed_url)
 
     def batched_remove(self, keys: List[CacheEngineKey]):
         """
         Perform batched remove in the lookup server.
         """
         logger.debug("Call to batched remove in lookup server")
+        if not keys:
+            return
         # TODO(Jiayi): We might need to cache the `str_keys` for performance.
-        str_keys = [key.to_string() for key in keys]
-        self.connection.delete(*str_keys)
+        pipe = self.connection.pipeline()
+        assert self.distributed_url is not None
+        for key in keys:
+            pipe.hdel(self._get_indexing_key(key), self.distributed_url)
+        pipe.execute()


### PR DESCRIPTION
* p2p indexing: Change format

This commit changes the p2p indexing format to be suitable for kv-cache-aware-routing. The new format is:
<model_name>@<chunk_hash> -> cache_instance_identifier -> <format>@<world_size>@<worker_id>@<timestamp>



* Enable p2p sharing in vllm v1

This commit fixes the cache_engine lookup function to enable p2p sharing in vllm v1.



* Allow indexing without sharing

This commit allows configuring LMCache to enable indexing (RedisLookupServer) without enabling p2p sharing (using NaiveDistributedServer). This new configuration will be applied if the distributed_url config parameter will be of the form <host> instead of <host>:<port>.
