### PR TITLE
p2p: Catch exceptions

### DIFF
--- a/lmcache/experimental/cache_engine.py
+++ b/lmcache/experimental/cache_engine.py
@@ -304,7 +304,16 @@ class LMCacheEngine:
                     future_memory_obj = asyncio.run_coroutine_threadsafe(
                         self.distributed_server.issue_get(key),
                         self.distributed_loop)
-                    memory_obj = future_memory_obj.result()
+                    try:
+                        memory_obj = future_memory_obj.result(
+                            self.config.p2p_retrieve_timeout)
+                    except TimeoutError:
+                        logger.warning(
+                            "Timeout while trying to read from peer")
+                        future_memory_obj.cancel()
+                    except Exception as exc:
+                        logger.warning(
+                            f"Got exception while reading from peer: {exc}")
                 if memory_obj is None:
                     break
 

--- a/lmcache/experimental/config.py
+++ b/lmcache/experimental/config.py
@@ -41,10 +41,12 @@ class LMCacheEngineConfig:
     lookup_batch_timeout: float = 0.1
     # maximum number of requests in the sending queue, 0 for infinite
     lookup_queue_size: int = 100000
-    lookup_timeout: float = 1.0  # time in seconds to wait for a lookup request
+    lookup_timeout: float = 0.2  # time in seconds to wait for a lookup request
 
     # P2P (only) related configurations
     enable_p2p: bool = False  # whether to enable peer-to-peer sharing
+    p2p_socket_timeout: float = 0.1  # timeout for peer socket ops
+    p2p_retrieve_timeout: float = 1.0  # timeout for total retrieval time
 
     # Error handling related configurations
     error_handling: bool = False  # whether to enable error handling
@@ -94,8 +96,10 @@ class LMCacheEngineConfig:
         lookup_batch_size: int = 10,
         lookup_batch_timeout: float = 0.1,
         lookup_queue_size: int = 100000,
-        lookup_timeout: float = 1.0,
+        lookup_timeout: float = 0.2,
         enable_p2p: bool = False,
+        p2p_socket_timeout: float = 0.1,
+        p2p_retrieve_timeout: float = 1.0,
         error_handling: bool = False,
         enable_controller: Optional[bool] = False,
         lmcache_instance_id: str = "lmcache_default_instance",
@@ -116,7 +120,8 @@ class LMCacheEngineConfig:
             enable_blending, blend_recompute_ratio, blend_min_tokens,
             blend_special_str, lookup_url, distributed_url, lookup_batch_size,
             lookup_batch_timeout, lookup_queue_size, lookup_timeout,
-            enable_p2p, error_handling, enable_controller, lmcache_instance_id,
+            enable_p2p, p2p_socket_timeout, p2p_retrieve_timeout,
+            error_handling, enable_controller, lmcache_instance_id,
             controller_url, lmcache_worker_url, enable_nixl, nixl_role,
             nixl_peer_host, nixl_peer_port, nixl_buffer_size,
             nixl_buffer_device, nixl_enable_gc).validate()
@@ -138,8 +143,10 @@ class LMCacheEngineConfig:
         lookup_batch_size: int = 10,
         lookup_batch_timeout: float = 0.1,
         lookup_queue_size: int = 100000,
-        lookup_timeout: float = 1.0,
+        lookup_timeout: float = 0.2,
         enable_p2p: bool = False,
+        p2p_socket_timeout: float = 0.1,
+        p2p_retrieve_timeout: float = 1.0,
         error_handling: bool = False,
     ) -> "LMCacheEngineConfig":
         # TODO (ApostaC): Add nixl config
@@ -187,7 +194,8 @@ class LMCacheEngineConfig:
             enable_blending, blend_recompute_ratio, blend_min_tokens,
             blend_special_str, lookup_url, distributed_url, lookup_batch_size,
             lookup_batch_timeout, lookup_queue_size, lookup_timeout,
-            enable_p2p, error_handling).validate().log_config()
+            enable_p2p, p2p_socket_timeout, p2p_retrieve_timeout,
+            error_handling).validate().log_config()
 
     @staticmethod
     def from_file(file_path: str) -> "LMCacheEngineConfig":
@@ -220,9 +228,11 @@ class LMCacheEngineConfig:
         lookup_batch_size = config.get("lookup_batch_size", 10)
         lookup_batch_timeout = config.get("lookup_batch_timeout", 0.1)
         lookup_queue_size = config.get("lookup_queue_size", 100000)
-        lookup_timeout = config.get("lookup_timeout", 1.0)
+        lookup_timeout = config.get("lookup_timeout", 0.2)
 
         enable_p2p = config.get("enable_p2p", False)
+        p2p_socket_timeout = config.get("p2p_socket_timeout", 0.1)
+        p2p_retrieve_timeout = config.get("p2p_retrieve_timeout", 1.0)
 
         error_handling = config.get("error_handling", False)
 
@@ -275,6 +285,8 @@ class LMCacheEngineConfig:
             lookup_queue_size,
             lookup_timeout,
             enable_p2p,
+            p2p_socket_timeout,
+            p2p_retrieve_timeout,
             error_handling,
             enable_controller,
             lmcache_instance_id,
@@ -376,6 +388,12 @@ class LMCacheEngineConfig:
 
         config.enable_p2p = to_bool(
             parse_env(get_env_name("enable_p2p"), config.enable_p2p))
+        config.p2p_socket_timeout = to_float(
+            parse_env(get_env_name("p2p_socket_timeout"),
+                      config.p2p_socket_timeout))
+        config.p2p_retrieve_timeout = to_float(
+            parse_env(get_env_name("p2p_retrieve_timeout"),
+                      config.p2p_retrieve_timeout))
 
         config.error_handling = to_bool(
             parse_env(get_env_name("error_handling"), config.error_handling))

--- a/lmcache/experimental/distributed_server/naive_server.py
+++ b/lmcache/experimental/distributed_server/naive_server.py
@@ -51,6 +51,7 @@ class NaiveDistributedServer(DistributedServerInterface):
         host, port = self.url.split(":")
         self.host = host
         self.port = int(port)
+        self.socket_timeout = config.p2p_socket_timeout
 
         self.loop = loop
         self.thread = threading.Thread(target=self.loop.run_forever)
@@ -117,26 +118,33 @@ class NaiveDistributedServer(DistributedServerInterface):
         # connection for 100 times.
         # However, too many live sockets could cause file descriptor exhaustion
         # (i.e., Too many open files).
-        client_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        client_socket.connect((host, port))
-        logger.debug(f"Peer connection created at {host}:{port}")
+        try:
+            with socket.socket(socket.AF_INET,
+                               socket.SOCK_STREAM) as client_socket:
+                client_socket.settimeout(self.socket_timeout)
+                client_socket.connect((host, port))
+                logger.debug(f"Peer connection created at {host}:{port}")
 
-        async with self.async_socket_lock:
-            client_socket.sendall(
-                ClientMetaMessage(Constants.CLIENT_GET, key, 0,
-                                  MemoryFormat(1), torch.float16,
-                                  torch.Size([0, 0, 0, 0])).serialize())
+                async with self.async_socket_lock:
+                    client_socket.sendall(
+                        ClientMetaMessage(Constants.CLIENT_GET, key, 0,
+                                          MemoryFormat(1), torch.float16,
+                                          torch.Size([0, 0, 0,
+                                                      0])).serialize())
 
-            data = client_socket.recv(ServerMetaMessage.packlength())
+                    data = client_socket.recv(ServerMetaMessage.packlength())
 
-        meta = ServerMetaMessage.deserialize(data)
-        if meta.code != Constants.SERVER_SUCCESS:
+                meta = ServerMetaMessage.deserialize(data)
+                if meta.code != Constants.SERVER_SUCCESS:
+                    return None
+
+                async with self.async_socket_lock:
+                    memory_obj = self.receive_all_client(meta, client_socket)
+
+                return memory_obj
+        except (socket.error, Exception) as e:
+            logger.error(f"Peer socket error: {e}")
             return None
-
-        async with self.async_socket_lock:
-            memory_obj = self.receive_all_client(meta, client_socket)
-
-        return memory_obj
 
     async def receive_all_server(self, reader, n):
         data = bytearray()


### PR DESCRIPTION
This PR fixes adds exception handling to p2p sharing.
Previously, if there was an error reading from a peer, it caused vllm to crash.
We also add a timeout (1 second).