### PR TITLE
RedisLookupServer: Batch requests

### DIFF
--- a/lmcache/experimental/cache_engine.py
+++ b/lmcache/experimental/cache_engine.py
@@ -415,6 +415,8 @@ class LMCacheEngine:
 
         if self.enable_p2p:
             self.distributed_server.close()
+        if hasattr(self, "lookup_server") and self.lookup_server is not None:
+            self.lookup_server.close()
 
         if self.lmcache_worker is not None:
             self.lmcache_worker.close()

--- a/lmcache/experimental/cache_engine.py
+++ b/lmcache/experimental/cache_engine.py
@@ -77,14 +77,13 @@ class LMCacheEngine:
         self.token_database = token_database
         self.gpu_connector = gpu_connector
 
-        self.enable_p2p = (config.enable_p2p and config.distributed_url
-                           and ":" in config.distributed_url)
+        self.enable_p2p = config.enable_p2p
 
         # NOTE: Unix systems use fork by default
         multiprocessing.set_start_method('spawn', force=True)
 
         self.lookup_server: Optional[LookupServerInterface] = None
-        if config.enable_p2p:
+        if config.lookup_url is not None:
             self.lookup_server = RedisLookupServer(config)
 
         # avoid circular import

--- a/lmcache/experimental/config.py
+++ b/lmcache/experimental/config.py
@@ -32,10 +32,19 @@ class LMCacheEngineConfig:
     blend_min_tokens: int  # the minimum number of tokens for blending
     blend_special_str: str = " # # "  # the separator for blending
 
-    # P2P related configurations
-    enable_p2p: bool = False  # whether to enable peer-to-peer sharing
+    # Lookup server (and P2P) related configurations
     lookup_url: Optional[str] = None  # the url of the lookup server
     distributed_url: Optional[str] = None  # the url of the distributed server
+    # maximal number of requests sent in a batch to the lookup server
+    lookup_batch_size: int = 10
+    # time in seconds to wait before closing up a batch of requests
+    lookup_batch_timeout: float = 0.1
+    # maximum number of requests in the sending queue, 0 for infinite
+    lookup_queue_size: int = 100000
+    lookup_timeout: float = 1.0  # time in seconds to wait for a lookup request
+
+    # P2P (only) related configurations
+    enable_p2p: bool = False  # whether to enable peer-to-peer sharing
 
     # Error handling related configurations
     error_handling: bool = False  # whether to enable error handling
@@ -80,9 +89,13 @@ class LMCacheEngineConfig:
         blend_recompute_ratio: float = 0.15,
         blend_min_tokens: int = 256,
         blend_special_str: str = " # # ",
-        enable_p2p: bool = False,
         lookup_url: Optional[str] = None,
         distributed_url: Optional[str] = None,
+        lookup_batch_size: int = 10,
+        lookup_batch_timeout: float = 0.1,
+        lookup_queue_size: int = 100000,
+        lookup_timeout: float = 1.0,
+        enable_p2p: bool = False,
         error_handling: bool = False,
         enable_controller: Optional[bool] = False,
         lmcache_instance_id: str = "lmcache_default_instance",
@@ -101,8 +114,9 @@ class LMCacheEngineConfig:
             chunk_size, local_cpu, max_local_cpu_size, local_disk,
             max_local_disk_size, remote_url, remote_serde, save_decode_cache,
             enable_blending, blend_recompute_ratio, blend_min_tokens,
-            blend_special_str, enable_p2p, lookup_url, distributed_url,
-            error_handling, enable_controller, lmcache_instance_id,
+            blend_special_str, lookup_url, distributed_url, lookup_batch_size,
+            lookup_batch_timeout, lookup_queue_size, lookup_timeout,
+            enable_p2p, error_handling, enable_controller, lmcache_instance_id,
             controller_url, lmcache_worker_url, enable_nixl, nixl_role,
             nixl_peer_host, nixl_peer_port, nixl_buffer_size,
             nixl_buffer_device, nixl_enable_gc).validate()
@@ -119,9 +133,13 @@ class LMCacheEngineConfig:
         blend_min_tokens: int = 256,
         blend_special_str: str = " # # ",
         max_local_disk_size: float = 0.0,
-        enable_p2p: bool = False,
         lookup_url: Optional[str] = None,
         distributed_url: Optional[str] = None,
+        lookup_batch_size: int = 10,
+        lookup_batch_timeout: float = 0.1,
+        lookup_queue_size: int = 100000,
+        lookup_timeout: float = 1.0,
+        enable_p2p: bool = False,
         error_handling: bool = False,
     ) -> "LMCacheEngineConfig":
         # TODO (ApostaC): Add nixl config
@@ -163,13 +181,13 @@ class LMCacheEngineConfig:
             max_local_disk_size = 5
         else:
             raise ValueError(f"Invalid backend: {backend}")
-        return LMCacheEngineConfig(chunk_size, local_cpu, max_local_cpu_size,
-                                   local_disk, max_local_disk_size, remote_url,
-                                   remote_serde, save_decode_cache,
-                                   enable_blending, blend_recompute_ratio,
-                                   blend_min_tokens, blend_special_str,
-                                   enable_p2p, lookup_url, distributed_url,
-                                   error_handling).validate().log_config()
+        return LMCacheEngineConfig(
+            chunk_size, local_cpu, max_local_cpu_size, local_disk,
+            max_local_disk_size, remote_url, remote_serde, save_decode_cache,
+            enable_blending, blend_recompute_ratio, blend_min_tokens,
+            blend_special_str, lookup_url, distributed_url, lookup_batch_size,
+            lookup_batch_timeout, lookup_queue_size, lookup_timeout,
+            enable_p2p, error_handling).validate().log_config()
 
     @staticmethod
     def from_file(file_path: str) -> "LMCacheEngineConfig":
@@ -197,9 +215,14 @@ class LMCacheEngineConfig:
         blend_min_tokens = config.get("blend_min_tokens", 256)
         blend_special_str = config.get("blend_special_str", " # # ")
 
-        enable_p2p = config.get("enable_p2p", False)
         lookup_url = config.get("lookup_url", None)
         distributed_url = config.get("distributed_url", None)
+        lookup_batch_size = config.get("lookup_batch_size", 10)
+        lookup_batch_timeout = config.get("lookup_batch_timeout", 0.1)
+        lookup_queue_size = config.get("lookup_queue_size", 100000)
+        lookup_timeout = config.get("lookup_timeout", 1.0)
+
+        enable_p2p = config.get("enable_p2p", False)
 
         error_handling = config.get("error_handling", False)
 
@@ -245,9 +268,13 @@ class LMCacheEngineConfig:
             blend_recompute_ratio,
             blend_min_tokens,
             blend_special_str,
-            enable_p2p,
             lookup_url,
             distributed_url,
+            lookup_batch_size,
+            lookup_batch_timeout,
+            lookup_queue_size,
+            lookup_timeout,
+            enable_p2p,
             error_handling,
             enable_controller,
             lmcache_instance_id,
@@ -331,12 +358,24 @@ class LMCacheEngineConfig:
         assert blend_special_str is not None
         config.blend_special_str = blend_special_str
 
-        config.enable_p2p = to_bool(
-            parse_env(get_env_name("enable_p2p"), config.enable_p2p))
         config.lookup_url = parse_env(get_env_name("lookup_url"),
                                       config.lookup_url)
         config.distributed_url = parse_env(get_env_name("distributed_url"),
                                            config.distributed_url)
+        config.lookup_batch_size = to_int(
+            parse_env(get_env_name("lookup_batch_size"),
+                      config.lookup_batch_size))
+        config.lookup_batch_timeout = to_float(
+            parse_env(get_env_name("lookup_batch_timeout"),
+                      config.lookup_batch_timeout))
+        config.lookup_queue_size = to_int(
+            parse_env(get_env_name("lookup_queue_size"),
+                      config.lookup_queue_size))
+        config.lookup_timeout = to_float(
+            parse_env(get_env_name("lookup_timeout"), config.lookup_timeout))
+
+        config.enable_p2p = to_bool(
+            parse_env(get_env_name("enable_p2p"), config.enable_p2p))
 
         config.error_handling = to_bool(
             parse_env(get_env_name("error_handling"), config.error_handling))
@@ -390,9 +429,10 @@ class LMCacheEngineConfig:
     def validate(self) -> 'LMCacheEngineConfig':
         """Validate the config
         """
+        if self.lookup_url is not None:
+            assert self.distributed_url is not None
         if self.enable_p2p:
             assert self.lookup_url is not None
-            assert self.distributed_url is not None
 
         if self.enable_nixl:
             assert self.nixl_role is not None
@@ -415,8 +455,8 @@ class LMCacheEngineConfig:
 
             assert self.save_decode_cache is False, \
                     "Nixl only supports save_decode_cache=False"
-            assert self.enable_p2p is False, \
-                    "Nixl only supports enable_p2p=False"
+            assert self.lookup_url is None, \
+                    "Nixl only supports lookup_url=None"
 
         return self
 
@@ -435,9 +475,9 @@ class LMCacheEngineConfig:
             'enable_blending': self.enable_blending,
             'blend_recompute_ratio': self.blend_recompute_ratio,
             'blend_min_tokens': self.blend_min_tokens,
-            'enable_p2p': self.enable_p2p,
             'lookup_url': self.lookup_url,
             'distributed_url': self.distributed_url,
+            'enable_p2p': self.enable_p2p,
             'error_handling': self.error_handling,
             'enable_controller': self.enable_controller,
             'lmcache_instance_id': self.lmcache_instance_id,

--- a/lmcache/experimental/lookup_server/abstract_server.py
+++ b/lmcache/experimental/lookup_server/abstract_server.py
@@ -42,3 +42,10 @@ class LookupServerInterface(metaclass=abc.ABCMeta):
         Perform batched remove in the lookup server.
         """
         raise NotImplementedError
+
+    @abc.abstractmethod
+    def close(self):
+        """
+        Close lookup server.
+        """
+        raise NotImplementedError

--- a/lmcache/experimental/lookup_server/redis_server.py
+++ b/lmcache/experimental/lookup_server/redis_server.py
@@ -15,9 +15,6 @@ from lmcache.utils import CacheEngineKey
 
 logger = init_logger(__name__)
 
-BATCH_SIZE = 10
-BATCH_TIMEOUT = 0.1  # time in seconds before closing-up batch
-
 
 class _WorkPriority(IntEnum):
     LOOKUP = 0  # Highest priority
@@ -45,15 +42,19 @@ class RedisLookupServer(LookupServerInterface):
         self.host = host
         self.port = int(port)
 
+        self.batch_timeout = config.lookup_batch_timeout
+        self.batch_size = config.lookup_batch_size
+        self.lookup_timeout = config.lookup_timeout
+
         self.connection = redis.Redis(host=self.host,
                                       port=self.port,
-                                      socket_timeout=1,
+                                      socket_timeout=self.lookup_timeout,
                                       decode_responses=True)
         logger.info(f"Connected to Redis lookup server at {host}:{port}")
         #decode_responses=False)
 
         self.queue: asyncio.PriorityQueue[tuple[_WorkPriority, _WorkItem]] = (
-            asyncio.PriorityQueue())
+            asyncio.PriorityQueue(config.lookup_queue_size))
         self.loop = asyncio.new_event_loop()
         self.thread = threading.Thread(target=self._run_loop, daemon=True)
         self.thread.start()
@@ -72,9 +73,9 @@ class RedisLookupServer(LookupServerInterface):
         if item.op == _Op.LOOKUP:
             timeout = 0.0  # lookups should not wait
         else:
-            timeout = BATCH_TIMEOUT
+            timeout = self.batch_timeout
 
-        for _ in range(BATCH_SIZE - 1):
+        for _ in range(self.batch_size - 1):
             try:
                 _, item = await asyncio.wait_for(self.queue.get(),
                                                  timeout=timeout)
@@ -158,7 +159,7 @@ class RedisLookupServer(LookupServerInterface):
 
         result = None
         try:
-            result = cfut.result(1)
+            result = cfut.result(self.lookup_timeout)
         except TimeoutError:
             logger.warning("Timeout while waiting for lookup")
             fut.cancel()

--- a/lmcache/experimental/lookup_server/redis_server.py
+++ b/lmcache/experimental/lookup_server/redis_server.py
@@ -1,6 +1,9 @@
-import inspect
+import asyncio
+import threading
 import time
-from typing import List, Optional, Tuple
+from collections import namedtuple
+from enum import Enum, IntEnum
+from typing import AsyncGenerator, List, Optional, Tuple
 
 import redis
 
@@ -12,13 +15,29 @@ from lmcache.utils import CacheEngineKey
 
 logger = init_logger(__name__)
 
+BATCH_SIZE = 10
+BATCH_TIMEOUT = 0.1  # time in seconds before closing-up batch
 
-# TODO (Jiayi): Batching is needed for Redis lookup server.
+
+class _WorkPriority(IntEnum):
+    LOOKUP = 0  # Highest priority
+    UPDATE = 1  # Lowest priority
+
+
+class _Op(Enum):
+    INSERT = 1
+    DELETE = 2
+    LOOKUP = 3
+
+
+_WorkItem = namedtuple('_WorkItem', ['key', 'op', 'fut'])
+
+
 class RedisLookupServer(LookupServerInterface):
 
     def __init__(self, config: LMCacheEngineConfig):
-        self.distributed_url = config.distributed_url
-        assert self.distributed_url is not None
+        assert config.distributed_url is not None
+        self.distributed_url: str = config.distributed_url
 
         self.url = config.lookup_url
         assert self.url is not None
@@ -28,31 +47,131 @@ class RedisLookupServer(LookupServerInterface):
 
         self.connection = redis.Redis(host=self.host,
                                       port=self.port,
+                                      socket_timeout=1,
                                       decode_responses=True)
         logger.info(f"Connected to Redis lookup server at {host}:{port}")
         #decode_responses=False)
 
-    def _get_indexing_key(self, key: CacheEngineKey):
+        self.queue: asyncio.PriorityQueue[tuple[_WorkPriority, _WorkItem]] = (
+            asyncio.PriorityQueue())
+        self.loop = asyncio.new_event_loop()
+        self.thread = threading.Thread(target=self._run_loop, daemon=True)
+        self.thread.start()
+        asyncio.run_coroutine_threadsafe(self._requester(), self.loop)
+
+    async def _get_batch(self) -> AsyncGenerator[_WorkItem, None]:
+        """
+        Batch work items as an async generator.
+
+        :yields: WorkItem's one by one as they are retrieved.
+        """
+        # wait for first item in batch
+        _, item = await self.queue.get()
+        yield item
+
+        if item.op == _Op.LOOKUP:
+            timeout = 0.0  # lookups should not wait
+        else:
+            timeout = BATCH_TIMEOUT
+
+        for _ in range(BATCH_SIZE - 1):
+            try:
+                _, item = await asyncio.wait_for(self.queue.get(),
+                                                 timeout=timeout)
+                yield item
+                if timeout > 0 and item.op == _Op.LOOKUP:
+                    timeout = 0  # lookups should not wait
+            except asyncio.TimeoutError:
+                break
+
+    def _add_to_pipeline(self, pipe: redis.client.Pipeline, item: _WorkItem):
+        """
+        Add a request to a redis pipeline (batch of requests).
+
+        :param redis.client.Pipeline pipe: The redis pipeline to add to.
+
+        :param _WorkItem item: The item defining the request we want to add.
+        """
+        match item.op:
+            case _Op.INSERT:
+                pipe.hset(self._get_indexing_key(item.key),
+                          self.distributed_url,
+                          self._get_indexing_metadata(item.key))
+            case _Op.DELETE:
+                pipe.hdel(self._get_indexing_key(item.key),
+                          self.distributed_url)
+            case _Op.LOOKUP:
+                pipe.hgetall(self._get_indexing_key(item.key))
+
+    async def _requester(self):
+        """
+        _requester batches requests to be sent to redis
+        """
+        while True:
+            items = []
+            with self.connection.pipeline() as pipe:
+                async for item in self._get_batch():
+                    self._add_to_pipeline(pipe, item)
+                    items.append(item)
+                logger.debug(f"Sending a batch of {len(items)} requests")
+                results = pipe.execute(raise_on_error=False)
+                logger.debug("Batch results are ready")
+
+            for item, result in zip(items, results):
+                if isinstance(result, Exception):
+                    item.fut.set_exception(result)
+                else:
+                    item.fut.set_result(result)
+
+    def _run_loop(self):
+        asyncio.set_event_loop(self.loop)
+        self.loop.run_forever()
+
+    def close(self):
+        if self.loop.is_running():
+            self.loop.call_soon_threadsafe(self.loop.stop)
+        if self.thread.is_alive():
+            self.thread.join()
+        self.connection.close()
+
+    def _get_indexing_key(self, key: CacheEngineKey) -> str:
         return f"{key.model_name}@{key.chunk_hash}"
 
-    def _get_indexing_metadata(self, key: CacheEngineKey):
+    def _get_indexing_metadata(self, key: CacheEngineKey) -> str:
         return f"{key.fmt}@{key.world_size}@{key.worker_id}@{time.time()}"
 
-    def _extract_cache_keys_componenets(self, indexing_metadata: str):
-        return indexing_metadata.split("@")[:-1]
+    def _extract_cache_keys_componenets(self, metadata: str) -> List[str]:
+        return metadata.split("@")[:-1]
 
     def lookup(self, key: CacheEngineKey) -> Optional[Tuple[str, int]]:
         """
         Perform lookup in the lookup server.
         """
         logger.debug("Call to lookup in lookup server")
-        result = self.connection.hgetall(self._get_indexing_key(key))
-        logger.debug(f"KV cache lives on {result}")
+        fut = self.loop.create_future()
+        item = _WorkItem(key, _Op.LOOKUP, fut)
+        asyncio.run_coroutine_threadsafe(
+            self.queue.put((_WorkPriority.LOOKUP, item)), self.loop)
+
+        cfut = asyncio.run_coroutine_threadsafe(_wait_for_future(fut),
+                                                self.loop)
+
+        result = None
+        try:
+            result = cfut.result(1)
+        except TimeoutError:
+            logger.warning("Timeout while waiting for lookup")
+            fut.cancel()
+        except Exception as exc:
+            logger.warning(f"Got exception while doing lookup: {exc}")
+
         if not result:
             return None
+
+        logger.debug(f"KV cache lives on {result}")
         comps = self._extract_cache_keys_componenets(
             self._get_indexing_metadata(key))
-        assert not inspect.isawaitable(result)
+
         for md_key, md_value in result.items():
             if comps == self._extract_cache_keys_componenets(md_value):
                 url = md_key
@@ -64,29 +183,40 @@ class RedisLookupServer(LookupServerInterface):
         """
         Perform insert in the lookup server.
         """
-        assert self.distributed_url is not None
         logger.debug("Call to insert in lookup server")
-        self.connection.hset(self._get_indexing_key(key), self.distributed_url,
-                             self._get_indexing_metadata(key))
+        fut = self.loop.create_future()
+        item = _WorkItem(key, _Op.INSERT, fut)
+        fut.add_done_callback(_log_result)
+        asyncio.run_coroutine_threadsafe(
+            self.queue.put((_WorkPriority.UPDATE, item)), self.loop)
 
     def remove(self, key: CacheEngineKey):
         """
         Perform remove in the lookup server.
         """
         logger.debug("Call to remove in lookup server")
-        assert self.distributed_url is not None
-        self.connection.hdel(self._get_indexing_key(key), self.distributed_url)
+        fut = self.loop.create_future()
+        item = _WorkItem(key, _Op.DELETE, fut)
+        fut.add_done_callback(_log_result)
+        asyncio.run_coroutine_threadsafe(
+            self.queue.put((_WorkPriority.UPDATE, item)), self.loop)
 
     def batched_remove(self, keys: List[CacheEngineKey]):
         """
         Perform batched remove in the lookup server.
         """
         logger.debug("Call to batched remove in lookup server")
-        if not keys:
-            return
-        # TODO(Jiayi): We might need to cache the `str_keys` for performance.
-        pipe = self.connection.pipeline()
-        assert self.distributed_url is not None
         for key in keys:
-            pipe.hdel(self._get_indexing_key(key), self.distributed_url)
-        pipe.execute()
+            self.remove(key)
+
+
+async def _wait_for_future(fut: asyncio.Future):
+    return await fut
+
+
+def _log_result(fut: asyncio.Future):
+    try:
+        result = fut.result()
+        logger.debug(f"Result: {result}")
+    except Exception as e:
+        logger.warning(f"Got exception: {e}")


### PR DESCRIPTION
This PR transformers RedisLookupServer to be fully asynchronous.

The basic flow is that API functions such as insert, remove and lookup simply create a "WorkItem" in an async priority queue (where lookups have the highest priority).
We add a single python thread which reads from this queue and batches requests which are sent to the redis server.
For lookups, we wait for a future which is set when the lookup gets back it response from the batch.

There is still an optimization to consider for caching repeated lookups (there are actually 2 identical lookups triggered per each kv loading).